### PR TITLE
[remo] Support offset in the cache

### DIFF
--- a/perceval/backends/mozilla/remo.py
+++ b/perceval/backends/mozilla/remo.py
@@ -70,7 +70,7 @@ class ReMo(Backend):
     :param tag: label used to mark the data
     :param cache: cache object to store raw data
     """
-    version = '0.4.0'
+    version = '0.5.0'
 
     def __init__(self, url=None, tag=None, cache=None):
         if not url:

--- a/perceval/backends/mozilla/remo.py
+++ b/perceval/backends/mozilla/remo.py
@@ -116,6 +116,8 @@ class ReMo(Backend):
         current_offset = offset
 
         self._purge_cache_queue()
+        # Add to the cache the offset so it can be used to recover from cache
+        self._push_cache_queue(offset)
 
         for raw_items in self.client.get_items(category, offset):
             self._push_cache_queue(raw_items)
@@ -140,6 +142,7 @@ class ReMo(Backend):
 
         logger.info("Total number of events: %i (%i total, %i offset)", nitems, titems, offset)
 
+    @remo_metadata
     @metadata
     def fetch_from_cache(self):
         """Fetch the items from the cache.
@@ -159,12 +162,18 @@ class ReMo(Backend):
         nitems = 0
 
         for item in cache_items:
+            if type(item) is int:
+                # offset from a new execution results in the cache
+                offset = item
+                item = next(cache_items)
             data = json.loads(item)
             # The raw_data is always a list of items or an item
             if 'count' in data:
                 # It is a list
                 continue
             else:
+                data['offset'] = offset
+                offset += 1
                 yield data
                 nitems += 1
 

--- a/tests/test_remo.py
+++ b/tests/test_remo.py
@@ -156,6 +156,7 @@ class TestReMoBackend(unittest.TestCase):
         self.assertEqual(items[0]['category'], 'event')
         self.assertEqual(items[0]['tag'], MOZILLA_REPS_SERVER_URL)
         self.assertEqual(items[0]['offset'], 0)
+        self.assertEqual(items[3]['offset'], 3)
 
     def __check_activities_contents(self, items):
         self.assertEqual(items[0]['data']['location'], 'Bhopal, Madhya Pradesh, India')
@@ -166,6 +167,7 @@ class TestReMoBackend(unittest.TestCase):
         self.assertEqual(items[0]['category'], 'activity')
         self.assertEqual(items[0]['tag'], MOZILLA_REPS_SERVER_URL)
         self.assertEqual(items[0]['offset'], 0)
+        self.assertEqual(items[3]['offset'], 3)
 
     def __check_users_contents(self, items):
         self.assertEqual(items[0]['data']['city'], 'Makati City')
@@ -176,6 +178,7 @@ class TestReMoBackend(unittest.TestCase):
         self.assertEqual(items[0]['category'], 'user')
         self.assertEqual(items[0]['tag'], MOZILLA_REPS_SERVER_URL)
         self.assertEqual(items[0]['offset'], 0)
+        self.assertEqual(items[3]['offset'], 3)
 
     @httpretty.activate
     def __test_fetch(self, category='events'):

--- a/tests/test_remo.py
+++ b/tests/test_remo.py
@@ -155,6 +155,7 @@ class TestReMoBackend(unittest.TestCase):
         self.assertEqual(items[0]['updated_on'], 1339326000.0)
         self.assertEqual(items[0]['category'], 'event')
         self.assertEqual(items[0]['tag'], MOZILLA_REPS_SERVER_URL)
+        self.assertEqual(items[0]['offset'], 0)
 
     def __check_activities_contents(self, items):
         self.assertEqual(items[0]['data']['location'], 'Bhopal, Madhya Pradesh, India')
@@ -164,6 +165,7 @@ class TestReMoBackend(unittest.TestCase):
         self.assertEqual(items[0]['updated_on'], 1478304000.0)
         self.assertEqual(items[0]['category'], 'activity')
         self.assertEqual(items[0]['tag'], MOZILLA_REPS_SERVER_URL)
+        self.assertEqual(items[0]['offset'], 0)
 
     def __check_users_contents(self, items):
         self.assertEqual(items[0]['data']['city'], 'Makati City')
@@ -173,6 +175,7 @@ class TestReMoBackend(unittest.TestCase):
         self.assertEqual(items[0]['updated_on'], 1306886400.0)
         self.assertEqual(items[0]['category'], 'user')
         self.assertEqual(items[0]['tag'], MOZILLA_REPS_SERVER_URL)
+        self.assertEqual(items[0]['offset'], 0)
 
     @httpretty.activate
     def __test_fetch(self, category='events'):
@@ -295,6 +298,7 @@ class TestReMoBackendCache(unittest.TestCase):
         self.assertEqual(len(cached_items), len(items))
         for i in range(0,len(items)):
             self.assertDictEqual(cached_items[i]['data'], items[i]['data'])
+            self.assertEqual(cached_items[i]['offset'], items[i]['offset'])
 
     def test_fetch_from_cache_events(self):
         self.__test_fetch_from_cache('events')


### PR DESCRIPTION
Right now in the perceval cache for remo the offset was not stored so items recovered from the cache have not the offset field. This patch fix it with the same approach than kitsune.