### PR TITLE
[init] Add perceval/__init__.py as in perceval

### DIFF
--- a/perceval/__init__.py
+++ b/perceval/__init__.py
@@ -1,0 +1,29 @@
+#
+# Copyright (C) 2015-2017 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA.
+#
+# Authors:
+#     Santiago Dueñas <sduenas@bitergia.com>
+#
+
+import logging
+
+from ._version import __version__
+from .backend import find_backends
+
+__all__ = [__version__, find_backends]
+
+logging.getLogger(__name__).addHandler(logging.NullHandler())

--- a/setup.py
+++ b/setup.py
@@ -69,9 +69,6 @@ setup(name="perceval-mozilla",
           'perceval.backends',
           'perceval.backends.mozilla'
       ],
-      namespaces=[
-          'perceval.backends'
-      ],
       install_requires=[
           'requests>=2.7.0',
           'grimoirelab-toolkit>=0.1.0',

--- a/tests/test_kitsune.py
+++ b/tests/test_kitsune.py
@@ -24,22 +24,15 @@
 
 import json
 import shutil
-import sys
 import tempfile
 import unittest
 
 import httpretty
-import pkg_resources
 import requests
 
 from perceval.backend import BackendCommandArgumentParser
 from perceval.cache import Cache
 from perceval.errors import CacheError
-
-# Hack to make sure that tests import the right packages
-# due to setuptools behaviour
-sys.path.insert(0, '..')
-pkg_resources.declare_namespace('perceval.backends')
 
 from perceval.backends.mozilla.kitsune import (Kitsune,
                                                KitsuneCommand,

--- a/tests/test_mozillaclub.py
+++ b/tests/test_mozillaclub.py
@@ -23,17 +23,10 @@
 #
 
 import shutil
-import sys
 import tempfile
 import unittest
 
 import httpretty
-import pkg_resources
-
-# Hack to make sure that tests import the right packages
-# due to setuptools behaviour
-sys.path.insert(0, '..')
-pkg_resources.declare_namespace('perceval.backends')
 
 from perceval.backend import BackendCommandArgumentParser
 from perceval.cache import Cache

--- a/tests/test_remo.py
+++ b/tests/test_remo.py
@@ -24,21 +24,14 @@
 
 import re
 import shutil
-import sys
 import tempfile
 import unittest
 
 import httpretty
-import pkg_resources
 
 from perceval.backend import BackendCommandArgumentParser
 from perceval.cache import Cache
 from perceval.errors import CacheError
-
-# Hack to make sure that tests import the right packages
-# due to setuptools behaviour
-sys.path.insert(0, '..')
-pkg_resources.declare_namespace('perceval.backends')
 
 from perceval.backends.mozilla.remo import (ReMo,
                                             ReMoCommand,


### PR DESCRIPTION
When installing this package after perceval, its (formerly empty) perceval/init.py file overwrites (or supersedes, depending on how it is installed) the one in the perceval package. That causes errors: see for example grimoirelab/perceval#190 or grimoirelab/perceval#171.

This is not the best fix, since it requires maintaining this file in sync in all perceval and perceval-* packackes, but for now, it does the trick.