### PR TITLE
[backends] Import perceval modules using relative paths

### DIFF
--- a/perceval/backends/mozilla/crates.py
+++ b/perceval/backends/mozilla/crates.py
@@ -30,12 +30,12 @@ from grimoirelab.toolkit.datetime import (datetime_utcnow,
                                           str_to_datetime)
 from grimoirelab.toolkit.uris import urijoin
 
-from perceval.backend import (Backend,
-                              BackendCommand,
-                              BackendCommandArgumentParser,
-                              metadata)
-from perceval.client import HttpClient
-from perceval.utils import DEFAULT_DATETIME
+from ...backend import (Backend,
+                        BackendCommand,
+                        BackendCommandArgumentParser,
+                        metadata)
+from ...client import HttpClient
+from ...utils import DEFAULT_DATETIME
 
 CRATES_URL = "https://crates.io/"
 CRATES_API_URL = 'https://crates.io/api/v1/'

--- a/perceval/backends/mozilla/kitsune.py
+++ b/perceval/backends/mozilla/kitsune.py
@@ -29,12 +29,12 @@ import requests
 from grimoirelab.toolkit.datetime import str_to_datetime
 from grimoirelab.toolkit.uris import urijoin
 
-from perceval.backend import (Backend,
-                              BackendCommand,
-                              BackendCommandArgumentParser,
-                              metadata)
-from perceval.client import HttpClient
-from perceval.errors import CacheError, ParseError
+from ...backend import (Backend,
+                        BackendCommand,
+                        BackendCommandArgumentParser,
+                        metadata)
+from ...client import HttpClient
+from ...errors import CacheError, ParseError
 
 
 logger = logging.getLogger(__name__)

--- a/perceval/backends/mozilla/mozillaclub.py
+++ b/perceval/backends/mozilla/mozillaclub.py
@@ -25,13 +25,13 @@ import logging
 
 from grimoirelab.toolkit.datetime import str_to_datetime
 
-from perceval.backend import (Backend,
-                              BackendCommand,
-                              BackendCommandArgumentParser,
-                              metadata)
-from perceval.client import HttpClient
-from perceval.errors import CacheError
-from perceval.utils import DEFAULT_DATETIME
+from ...backend import (Backend,
+                        BackendCommand,
+                        BackendCommandArgumentParser,
+                        metadata)
+from ...client import HttpClient
+from ...errors import CacheError
+from ...utils import DEFAULT_DATETIME
 
 
 logger = logging.getLogger(__name__)

--- a/perceval/backends/mozilla/remo.py
+++ b/perceval/backends/mozilla/remo.py
@@ -27,12 +27,12 @@ import logging
 from grimoirelab.toolkit.datetime import str_to_datetime
 from grimoirelab.toolkit.uris import urijoin
 
-from perceval.backend import (Backend,
-                              BackendCommand,
-                              BackendCommandArgumentParser,
-                              metadata)
-from perceval.client import HttpClient
-from perceval.errors import CacheError
+from ...backend import (Backend,
+                        BackendCommand,
+                        BackendCommandArgumentParser,
+                        metadata)
+from ...client import HttpClient
+from ...errors import CacheError
 
 
 logger = logging.getLogger(__name__)

--- a/tests/test_mozillaclub.py
+++ b/tests/test_mozillaclub.py
@@ -31,7 +31,10 @@ import httpretty
 from perceval.backend import BackendCommandArgumentParser
 from perceval.cache import Cache
 from perceval.errors import CacheError
-from perceval.backends.mozilla.mozillaclub import MozillaClub, MozillaClubCommand, MozillaClubClient, MozillaClubParser
+from perceval.backends.mozilla.mozillaclub import (MozillaClub,
+                                                   MozillaClubCommand,
+                                                   MozillaClubClient,
+                                                   MozillaClubParser)
 
 
 MozillaClub_FEED_URL = 'http://example.com/feed'


### PR DESCRIPTION
This patch changes the way how perceval modules are imported. Now absolute paths are replaced by relative ones.