### PR TITLE
[crates] Fix None sleep_time when using CratesCmd

### DIFF
--- a/perceval/backends/mozilla/crates.py
+++ b/perceval/backends/mozilla/crates.py
@@ -43,7 +43,7 @@ CRATES_API_URL = 'https://crates.io/api/v1/'
 CRATES_CATEGORY = 'crates'
 SUMMARY_CATEGORY = 'summary'
 
-SLEEP_TIME = 300
+SLEEP_TIME = 60
 
 logger = logging.getLogger(__name__)
 
@@ -57,7 +57,7 @@ class Crates(Backend):
     :param tag: label used to mark the data
     :param cache: use issues already retrieved in cache
     """
-    version = '0.1.2'
+    version = '0.1.3'
 
     def __init__(self, sleep_time=SLEEP_TIME, tag=None, cache=None):
         origin = CRATES_URL
@@ -316,6 +316,7 @@ class CratesCommand(BackendCommand):
         # Optional arguments
         group = parser.parser.add_argument_group('Crates.io arguments')
         group.add_argument('--sleep-time', dest='sleep_time',
+                           default=SLEEP_TIME, type=int,
                            help="Sleep time in case of connection lost")
         group.add_argument('--category', default=CRATES_CATEGORY,
                            choices=(CRATES_CATEGORY, SUMMARY_CATEGORY),

--- a/tests/test_crates.py
+++ b/tests/test_crates.py
@@ -31,6 +31,7 @@ from perceval.backend import BackendCommandArgumentParser
 from perceval.backends.mozilla.crates import (Crates,
                                               CratesClient,
                                               CratesCommand,
+                                              SLEEP_TIME,
                                               CRATES_CATEGORY,
                                               SUMMARY_CATEGORY)
 
@@ -394,7 +395,14 @@ class TestCratesCommand(unittest.TestCase):
         self.assertEqual(parsed_args.tag, 'test')
         self.assertEqual(parsed_args.from_date, DEFAULT_DATETIME)
         self.assertEqual(parsed_args.category, SUMMARY_CATEGORY)
-        self.assertEqual(parsed_args.sleep_time, '600')
+        self.assertEqual(parsed_args.sleep_time, 600)
+
+        args = ['--tag', 'test',
+                '--from-date', '1970-01-01',
+                '--category', 'summary']
+        parsed_args = parser.parse(*args)
+
+        self.assertEqual(parsed_args.sleep_time, SLEEP_TIME)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This patch fixes issues #13. The sleep_time parameter was not initialized with the default value when launching the Crates backend from command line.